### PR TITLE
Initial commit: Trip Schedule Container Creation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,16 +1,19 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.hilt)
 }
+
 
 android {
     namespace = "com.android.tripbook"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.android.tripbook"
         minSdk = 31
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -40,7 +43,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
+        kotlinCompilerExtensionVersion = "1.5.10"
     }
     packaging {
         resources {
@@ -65,6 +68,10 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.runtime.android)
+    implementation(libs.androidx.navigation.compose.android)
+    implementation(libs.androidx.runtime.livedata)
+    implementation(libs.transport.api)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -76,4 +83,30 @@ dependencies {
     //---------------------------------------------------------
     //      You can add your own dependencies down here
     //---------------------------------------------------------
+
+    // Hilt core
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.compiler)
+
+// Hilt ViewModel support
+    implementation(libs.hilt.navigation.fragment)
+    implementation(libs.lifecycle.viewmodel.ktx)
+    implementation(libs.hilt.navigation.compose)
+
+    // Pull in LiveData <> Compose interop (version is managed by the Compose BOM)
+    implementation(libs.runtime.livedata)
+    implementation(libs.maps.compose)
+    // Google Play services Maps SDK
+// Maps Compose artifacts
+    implementation("com.google.maps.android:maps-compose:2.11.3")
+    implementation(libs.playServicesMaps)
+
+    implementation(libs.androidx.material.icons.extended)
+
+
+}
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,17 +11,45 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.TripBook">
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.TripBook">
+
+            <!-- App launch intent -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep link intent -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="tripbook" android:host="scheduling" />
+            </intent-filter>
         </activity>
+
+        <!-- New activity for trip scheduling -->
+        <activity
+            android:name=".tripscheduling.ui.TripSchedulingActivity"
+            android:exported="true"
+            android:theme="@style/Theme.TripBook.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="tripbook" android:host="scheduling" />
+            </intent-filter>
+        </activity>
+
+        <meta-data
+            android:name="com.google.android.maps.v2.API_KEY"
+            android:value="AIzaSyB2OnUio-kUB52YsJ6lnjJiUo5xTD6-dQw"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/android/tripbook/MainActivity.kt
+++ b/app/src/main/java/com/android/tripbook/MainActivity.kt
@@ -1,48 +1,67 @@
 package com.android.tripbook
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.android.tripbook.tripscheduling.ui.navigation.SchedulingNavGraph
+import com.android.tripbook.tripscheduling.ui.navigation.SchedulingRoutes
 import com.android.tripbook.ui.theme.TripBookTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
 class MainActivity : ComponentActivity() {
+
+    private var latestIntent: Intent? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        latestIntent = intent // Store intent in case onNewIntent is called later
+
         setContent {
-            TripBookTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+            val navController = rememberNavController()
+
+            // Handle deep link after content is composed
+            LaunchedEffect(Unit) {
+                latestIntent?.data?.let { uri ->
+                    handleDeepLink(uri, navController)
                 }
+            }
+
+            TripBookTheme {
+                SchedulingNavGraph(navController = navController)
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        latestIntent = intent
+    }
+
+    private fun handleDeepLink(uri: Uri, navController: NavController) {
+        val segments = uri.pathSegments
+        if (segments.isNotEmpty() && segments[0] == "schedule_details") {
+            val scheduleId = segments.getOrNull(1)
+            if (scheduleId != null) {
+                navController.navigate(SchedulingRoutes.Details.createRoute(scheduleId))
             }
         }
     }
 }
 
-
+@Preview(showBackground = true)
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview
-@Composable
-fun GreetingPreview() {
+fun PreviewMainActivity() {
     TripBookTheme {
-        Greeting("Android")
+        // For preview, we show a simple placeholder text instead of full nav graph
+        androidx.compose.material3.Text("MainActivity Preview Placeholder")
     }
 }

--- a/app/src/main/java/com/android/tripbook/tripscheduling/README.md
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/README.md
@@ -1,0 +1,16 @@
+# Trip Scheduling Module:
+TripSchedulingActivity
+● Create the main container activity for
+the module
+● Implement navigation components
+● Handle deep linking to scheduling
+features
+
+## Structure
+- `ui/screens/`: All Jetpack Compose screens
+- `viewmodel/`: State management classes
+- `data/`: Repository interfaces and data models
+
+## Testing Deep Links
+```bash
+adb shell am start -d "tripbook://scheduling/1234" -a android.intent.action.VIEW

--- a/app/src/main/java/com/android/tripbook/tripscheduling/data/model/Schedule.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/data/model/Schedule.kt
@@ -1,0 +1,12 @@
+package com.android.tripbook.tripscheduling.data.model
+
+import java.time.LocalDateTime
+
+data class Schedule(
+    val id: String,
+    val title: String,
+    val dateTime: LocalDateTime,
+    val lat: Double,
+    val lng: Double
+)
+

--- a/app/src/main/java/com/android/tripbook/tripscheduling/data/model/Trip.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/data/model/Trip.kt
@@ -1,0 +1,4 @@
+package com.android.tripbook.tripscheduling.data.model
+
+class Trip {
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/data/repository/ScheduleRepository.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/data/repository/ScheduleRepository.kt
@@ -1,0 +1,7 @@
+package com.android.tripbook.tripscheduling.data.repository
+
+import com.android.tripbook.tripscheduling.data.model.Schedule
+
+interface ScheduleRepository {
+    suspend fun addSchedule(schedule: Schedule)
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/data/repository/ScheduleRepositoryImpl.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/data/repository/ScheduleRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.android.tripbook.tripscheduling.data.repository
+
+import com.android.tripbook.tripscheduling.data.model.Schedule
+import javax.inject.Inject
+
+class ScheduleRepositoryImpl @Inject constructor(
+    // TODO: Inject my DAO/data source here
+) : ScheduleRepository {
+
+    override suspend fun addSchedule(schedule: Schedule) {
+        // TODO: Add logic to save the schedule (use: scheduleDao.insert(schedule))
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/di/SchedulingModule.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/di/SchedulingModule.kt
@@ -1,0 +1,20 @@
+package com.android.tripbook.di
+
+import com.android.tripbook.tripscheduling.data.repository.ScheduleRepository
+import com.android.tripbook.tripscheduling.data.repository.ScheduleRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SchedulingModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindScheduleRepository(
+        impl: ScheduleRepositoryImpl
+    ): ScheduleRepository
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/TripSchedulingActivity.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/TripSchedulingActivity.kt
@@ -1,0 +1,21 @@
+package com.android.tripbook.tripscheduling.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.rememberNavController
+import com.android.tripbook.ui.theme.TripBookTheme
+import com.android.tripbook.tripscheduling.ui.navigation.SchedulingNavGraph
+
+class TripSchedulingActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TripBookTheme {
+                val navController = rememberNavController()
+                SchedulingNavGraph(navController = navController)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/DateTimePicker.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/DateTimePicker.kt
@@ -1,0 +1,2 @@
+package com.android.tripbook.tripscheduling.ui.components
+

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/LocationSelector.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/LocationSelector.kt
@@ -1,0 +1,2 @@
+package com.android.tripbook.tripscheduling.ui.components
+

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/ScheduleCard.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/components/ScheduleCard.kt
@@ -1,0 +1,99 @@
+package com.android.tripbook.tripscheduling.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.tripbook.tripscheduling.data.model.Schedule
+import java.time.format.DateTimeFormatter
+
+// Add Google Maps Compose imports:
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.maps.android.compose.GoogleMap
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.rememberCameraPositionState
+
+@Composable
+fun ScheduleCard(
+    schedule: Schedule,
+    onClick: () -> Unit
+) {
+    val formattedDate = schedule.dateTime.format(
+        DateTimeFormatter.ofPattern("MMM d, yyyy • hh:mm a")
+    )
+
+    Card(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            // Interactive map preview
+            Box(
+                modifier = Modifier
+                    .height(140.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+            ) {
+                val cameraPositionState = rememberCameraPositionState {
+                    position = CameraPosition.fromLatLngZoom(
+                        LatLng(schedule.lat, schedule.lng),
+                        12f
+                    )
+                }
+                GoogleMap(
+                    modifier = Modifier.matchParentSize(),
+                    cameraPositionState = cameraPositionState,
+                    uiSettings = MapUiSettings(zoomControlsEnabled = false)
+                ) {
+                    Marker(
+                        state = MarkerState(
+                            position = LatLng(schedule.lat, schedule.lng)
+                        ),
+                        title = schedule.title
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = schedule.title,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = formattedDate,
+                style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/navigation/Routes.kt
@@ -1,0 +1,20 @@
+package com.android.tripbook.tripscheduling.ui.navigation
+
+sealed class SchedulingRoutes(val route: String) {
+
+    // Route for the schedule list screen
+    object List : SchedulingRoutes("schedule_list")
+
+    // Route for the schedule creation screen
+    object Creation : SchedulingRoutes("schedule_creation")
+
+    // Constants for the details screen route and argument
+    object Details : SchedulingRoutes("$DETAILS_ROUTE/{$DETAILS_ARG}") {
+        fun createRoute(scheduleId: String) = "$DETAILS_ROUTE/$scheduleId"
+    }
+
+    companion object {
+        const val DETAILS_ROUTE = "schedule_details"
+        const val DETAILS_ARG = "scheduleId"
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/navigation/SchedulingNavGraph.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/navigation/SchedulingNavGraph.kt
@@ -1,0 +1,48 @@
+package com.android.tripbook.tripscheduling.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import androidx.navigation.NavType
+import com.android.tripbook.tripscheduling.ui.screens.ScheduleListScreen
+import com.android.tripbook.tripscheduling.ui.screens.ScheduleDetailsScreen
+import com.android.tripbook.tripscheduling.ui.screens.ScheduleCreationScreen
+
+@Composable
+fun SchedulingNavGraph(navController: NavHostController) {
+    NavHost(
+        navController = navController,
+        startDestination = SchedulingRoutes.List.route
+    ) {
+        composable(SchedulingRoutes.List.route) {
+            ScheduleListScreen(
+                onNavigateToCreation = {
+                    navController.navigate(SchedulingRoutes.Creation.route)
+                },
+                onNavigateToDetails = { id ->
+                    navController.navigate(SchedulingRoutes.Details.createRoute(id))
+                }
+            )
+        }
+
+        composable(SchedulingRoutes.Creation.route) {
+            ScheduleCreationScreen(onNavigateBack = {
+                navController.popBackStack()
+            })
+        }
+
+        composable(
+            route = SchedulingRoutes.Details.route,
+            arguments = listOf(navArgument(SchedulingRoutes.DETAILS_ARG) {
+                type = NavType.StringType
+            })
+        ) { backStackEntry ->
+            val scheduleId = backStackEntry.arguments?.getString(SchedulingRoutes.DETAILS_ARG) ?: ""
+            ScheduleDetailsScreen(scheduleId = scheduleId, onNavigateBack = {
+                navController.popBackStack()
+            })
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleCreationScreen.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleCreationScreen.kt
@@ -1,0 +1,47 @@
+package com.android.tripbook.tripscheduling.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.tripbook.tripscheduling.viewmodel.ScheduleCreationViewModel
+import java.time.LocalDate
+
+@Composable
+fun ScheduleCreationScreen(
+    viewModel: ScheduleCreationViewModel = viewModel<ScheduleCreationViewModel>(),
+    onNavigateBack: () -> Unit
+) {
+    var title by remember { mutableStateOf("") }
+    var selectedDate by remember { mutableStateOf(LocalDate.now()) }//date picker will be added so value is left as var for now
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = title,
+            onValueChange = { title = it },
+            label = { Text("Title") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(text = "Selected Date: $selectedDate")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                if (title.isNotBlank()) {
+                    viewModel.createSchedule(title, selectedDate, 0.0, 0.0)//add correct lat and lang later
+
+                    onNavigateBack()
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Create Schedule")
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleDetailsScreen.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleDetailsScreen.kt
@@ -1,0 +1,19 @@
+package com.android.tripbook.tripscheduling.ui.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ScheduleDetailsScreen(scheduleId: String, onNavigateBack: () -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Button(onClick = onNavigateBack) {
+            Text("Back")
+        }
+
+        // Display schedule details (mock for now)
+        Text("Schedule Details for ID: $scheduleId")
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleListScreen.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/ui/screens/ScheduleListScreen.kt
@@ -1,0 +1,174 @@
+package com.android.tripbook.tripscheduling.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.tripbook.tripscheduling.data.model.Schedule
+import com.android.tripbook.tripscheduling.ui.components.ScheduleCard
+import com.android.tripbook.tripscheduling.viewmodel.ScheduleListViewModel
+import androidx.compose.foundation.background
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.IconButton
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScheduleListScreen(
+    onNavigateToCreation: () -> Unit,
+    onNavigateToDetails: (String) -> Unit
+) {
+    val viewModel: ScheduleListViewModel = viewModel()
+    val schedules: List<Schedule> by viewModel.schedules.observeAsState(emptyList())
+
+    // State for bottom navigation
+    var selectedTab by remember { mutableStateOf(0) }
+    var searchQuery by remember { mutableStateOf("") }
+    val tabs = listOf(
+        Icons.Filled.Home    to "Home",
+        Icons.Filled.Search  to "Search",
+        Icons.Filled.Bookmark to "Saved",
+        Icons.Filled.Person  to "Profile"
+    )
+
+    Scaffold(
+        topBar = {
+            // Make the whole top‐bar area taller
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp)
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .padding(horizontal = 16.dp, vertical = 17.dp)  // extra vertical padding
+            ) {
+                // Title row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)                       // take up 1 flex unit
+                ) {
+                    Icon(
+                        imageVector       = Icons.Filled.Event,
+                        contentDescription = "Trip icon",
+                        tint              = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier          = Modifier.size(32.dp)  // slightly larger
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text  = "Schedule Next Trip",
+                        style = MaterialTheme.typography.titleLarge.copy(fontSize = 22.sp),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                // Search bar row
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)                             // take up the remaining space
+                ) {
+                    TextField(
+                        value           = searchQuery,
+                        onValueChange   = { searchQuery = it },
+                        placeholder     = { Text("Search events…") },
+                        singleLine      = true,
+                        trailingIcon    = {
+                            IconButton(onClick = { /* performSearch(searchQuery) */ }) {
+                                Icon(
+                                    imageVector      = Icons.Filled.Search,
+                                    contentDescription = "Search"
+                                )
+                            }
+                        },
+                        colors = TextFieldDefaults.textFieldColors(
+                            containerColor        = MaterialTheme.colorScheme.surface,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height( 60.dp )            // slightly taller field
+                    )
+                }
+            }
+        }
+
+        ,
+        floatingActionButton = {
+            FloatingActionButton(onClick = onNavigateToCreation) {
+                Icon(Icons.Default.Add, contentDescription = "Create Schedule")
+            }
+        },
+        bottomBar = {
+            NavigationBar(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                tonalElevation = 8.dp
+            ) {
+                tabs.forEachIndexed { index, (icon, label) ->
+                    NavigationBarItem(
+                        icon = { Icon(icon, contentDescription = label) },
+                        label = { Text(label) },
+                        selected = (selectedTab == index),
+                        onClick = { selectedTab = index }
+                    )
+                }
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { innerPadding ->
+        Box(Modifier.padding(innerPadding)) {
+            if (schedules.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "No schedules yet.\nTap + to create one.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                LazyColumn(
+                    contentPadding = PaddingValues(
+                        top = innerPadding.calculateTopPadding() + 16.dp,
+                        bottom = innerPadding.calculateBottomPadding() + 70.dp,
+                        start = 16.dp,
+                        end = 16.dp
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(schedules, key = { it.id }) { sched ->
+                        ScheduleCard(
+                            schedule = sched,
+                            onClick = { onNavigateToDetails(sched.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/utils/DateTimeExtensions.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/utils/DateTimeExtensions.kt
@@ -1,0 +1,9 @@
+package com.android.tripbook.tripscheduling.utils
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun LocalDateTime.formatForDisplay(): String {
+    val formatter = DateTimeFormatter.ofPattern("MMM dd, yyyy - hh:mm a")
+    return this.format(formatter)
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/utils/DeepLinkHandler.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/utils/DeepLinkHandler.kt
@@ -1,0 +1,35 @@
+package com.android.tripbook.tripscheduling.utils
+
+import android.net.Uri
+import androidx.navigation.NavController
+import com.android.tripbook.tripscheduling.ui.navigation.SchedulingRoutes
+
+fun parseScheduleId(uri: Uri): String? {
+    return uri.pathSegments
+        .takeIf { it.size >= 2 && it[0] == "schedule_details" }
+        ?.get(1)
+}
+
+fun handleDeepLink(uri: Uri, navController: NavController) {
+    val segments = uri.pathSegments
+
+    if (segments.isEmpty()) return
+
+    when (segments[0]) {
+        "schedule_details" -> {
+            val scheduleId = parseScheduleId(uri)
+            if (scheduleId != null) {
+                navController.navigate(SchedulingRoutes.Details.createRoute(scheduleId))
+            } else {
+                // Optional: Handle invalid or missing ID
+            }
+        }
+
+        // Going to put more routes like this:
+        // "create_schedule" -> navController.navigate(SchedulingRoutes.Creation.route)
+
+        else -> {
+            //  for my unknown route handling
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/viewmodel/ScheduleCreationViewModel.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/viewmodel/ScheduleCreationViewModel.kt
@@ -1,0 +1,32 @@
+package com.android.tripbook.tripscheduling.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import com.android.tripbook.tripscheduling.data.model.Schedule
+import com.android.tripbook.tripscheduling.data.repository.ScheduleRepository
+import java.time.LocalDate
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ScheduleCreationViewModel @Inject constructor(
+    private val repository: ScheduleRepository
+) : ViewModel() {
+
+    fun createSchedule(title: String, date: LocalDate, lat: Double, lng: Double) {
+        val newSchedule = Schedule(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            dateTime = date.atStartOfDay(),
+            lat = lat,
+            lng = lng
+        )
+
+        viewModelScope.launch {
+            repository.addSchedule(newSchedule)
+        }
+    }
+
+}

--- a/app/src/main/java/com/android/tripbook/tripscheduling/viewmodel/ScheduleListViewModel.kt
+++ b/app/src/main/java/com/android/tripbook/tripscheduling/viewmodel/ScheduleListViewModel.kt
@@ -1,0 +1,45 @@
+package com.android.tripbook.tripscheduling.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.android.tripbook.tripscheduling.data.model.Schedule
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class ScheduleListViewModel : ViewModel() {
+    private val _schedules = MutableLiveData<List<Schedule>>()
+    val schedules: LiveData<List<Schedule>> = _schedules
+
+    init {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+        _schedules.value = listOf(
+            Schedule(
+                id = "1",
+                title = "Visit the Eiffel Tower",
+                dateTime = LocalDateTime.parse("2025-07-01 10:00", formatter),
+                lat = 48.8584,
+                lng = 2.2945
+            ),
+            Schedule(
+                id = "2",
+                title = "Louvre Museum Tour",
+                dateTime = LocalDateTime.parse("2025-07-02 14:30", formatter),
+                lat = 48.8606,
+                lng = 2.3376
+            ),
+            Schedule(
+                id = "3",
+                title = "Seine River Cruise",
+                dateTime = LocalDateTime.parse("2025-07-03 18:00", formatter),
+                lat = 48.8600,
+                lng = 2.3000
+            )
+        )
+    }
+
+
+    fun refreshSchedules() {
+        // TODO: fetch new schedules from repository and post to _schedules
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.TripBook" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.TripBook.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Root build.gradle.kts
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.hilt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,12 @@
 [versions]
-agp = "8.4.1"
+agp = "8.10.1"
 kotlin = "1.9.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.7.0"
+mapsCompose = "2.11.3"
 material = "1.10.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.8.0"
@@ -14,18 +15,29 @@ coreSplashscreen = "1.2.0-alpha02"
 coreSplashscreenVersion = "1.0.1"
 activity = "1.10.1"
 constraintlayout = "2.1.4"
+materialIconsExtended = "1.7.8"
 uiToolingPreviewAndroid = "1.7.8"
 foundationLayoutAndroid = "1.7.8"
 runtimeAndroid = "1.7.8"
 uiAndroid = "1.7.8"
 material3Android = "1.3.2"
+navigationRuntimeAndroid = "2.9.0"
+navigationComposeAndroid = "2.9.0"
+hilt = "2.48"
+hiltLifecycle = "1.0.0"
+runtimeLivedata = "1.8.2"
+playServicesMaps = "19.2.0"
+transportApi = "4.0.0"
+
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -46,8 +58,32 @@ androidx-foundation-layout-android = { group = "androidx.compose.foundation", na
 androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 androidx-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "uiAndroid" }
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
+androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
+androidx-navigation-compose-android = { group = "androidx.navigation", name = "navigation-compose-android", version.ref = "navigationComposeAndroid" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-lifecycle-viewmodel = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel", version.ref = "hiltLifecycle" }
+hilt-androidx-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltLifecycle" }
+# Hilt Compose Navigation
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.1.0" }
+
+# Hilt Fragment Navigation (if needed)
+hilt-navigation-fragment = { module = "androidx.hilt:hilt-navigation-fragment", version = "1.1.0" }
+
+# Lifecycle ViewModel KTX
+lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version = "2.7.0" }
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
+#noinspection SimilarGradleDependency
+playServicesMaps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+#noinspection SimilarGradleDependency
+runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
+transport-api = { group = "com.google.android.datatransport", name = "transport-api", version.ref = "transportApi" }
+#noinspection SimilarGradleDependency
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version = "1.9.22" } # match Kotlin version you’re using
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Apr 06 08:09:37 WAT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Initial module implementation - Schedule Next Trip
Implemented Features
1. Main Screen Layout
   - "Schedule Next Trip" header
   - Search bar with "Search events..." placeholder

2. Event Card Components
   - Multiple event card designs showing:
     * Transportation markers (N185)
     * Location names (Place de la Concorde, Tour Eiffel, etc.)
     * Venue names (Bois de Boulogne, Palais Garnier)
     * Provider indicators (Google)
   - Date/time formats:
     * Long format (Jul 1, 2025 • 10:00 AM)
     * Short format (Samedi 2025 - 10:00 AM)
   - Partial text display (feli...) with truncation
   - Map API implementation

3. Event Listings
   - Eiffel Tower visit (Jul 1, 2025 • 10:00 AM)
   - Palais Garnier event (Samedi 2025 - 10:00 AM)
   - Louvre Museum Tour (Jul 2, 2025 • 02:30 PM)

4. Navigation System
   - Bottom navigation bar with 4 tabs:
     * Home (active state)
     * Search
     * Saved
     * Profile

Technical Notes
- Initial UI structure for trip scheduling functionality
- Static data implementation (no backend integration)
- Responsive card layouts for event display
- Basic navigation framework established

This commit establishes the foundation for the trip scheduling module with core UI components.