### PR TITLE
Add Navigation Between Company Catalog and Detail Screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # TripBook
-TripBook: A mobile social network for travelers exploring Africa &amp; beyond. Share stories, photos, and tips, rate travel agencies, and connect with adventurers. Community-driven platform to discover hidden gems, promote tourism, and ensure safer journeys. Built with React Native, Node.js &amp; geolocation APIs. Contributions welcome! 🌍✨
+ 

--- a/app/src/main/java/com/android/tripbook/companycatalog/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/android/tripbook/companycatalog/navigation/AppNavigation.kt
@@ -3,3 +3,52 @@
     catalog screen to detailed company pages while handling missing company cases.
  */
 package com.android.tripbook.companycatalog.navigation
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost // Explicit import
+import androidx.navigation.compose.composable // Explicit import
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.android.tripbook.companycatalog.model.MockCompanyData
+import com.android.tripbook.companycatalog.ui.catalog.CompanyCatalogScreen
+
+@Composable
+fun AppNavigation() {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = Routes.CATALOG_SCREEN
+    ) {
+        composable(Routes.CATALOG_SCREEN) {
+            CompanyCatalogScreen(
+                onCompanyClick = { company ->
+                    navController.navigate("${Routes.DETAIL_SCREEN}/${company.id}")
+                }
+            )
+        }
+
+        composable(
+            route = "${Routes.DETAIL_SCREEN}/{companyId}",
+            arguments = listOf(navArgument("companyId") { type = NavType.IntType })
+        ) { backStackEntry ->
+            val companyId = backStackEntry.arguments?.getInt("companyId")
+            val company = MockCompanyData.companies.find { it.id == companyId
+}
+
+            if (company != null) {
+                // Pass the onBackClick lambda to CompanyDetailScreen
+                CompanyDetailScreen(
+                    company = company,
+                    onBackClick = {
+                        navController.popBackStack() // Navigate back when the back button is clicked
+                    }
+                )
+            } else {
+                // TODO: Handle case where company is not found, e.g., show error screen or navigate back
+                // For now, let's navigate back if company is null to avoid a blank screen
+                        navController.popBackStack()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/tripbook/companycatalog/navigation/Routes.kt
+++ b/app/src/main/java/com/android/tripbook/companycatalog/navigation/Routes.kt
@@ -4,3 +4,7 @@
  */
 
 package com.android.tripbook.companycatalog.navigation
+object Routes {
+    const val CATALOG_SCREEN = "company_catalog"
+    const val DETAIL_SCREEN = "company_detail"
+}


### PR DESCRIPTION
Overview
This PR implements a structured navigation system using Jetpack Compose's NavHost to connect the Company Catalog screen with Company Detail pages.

Key Changes
Introduced AppNavigation() as the navigation graph.

Enabled navigation to detail screens via company ID.

Handled missing or invalid company IDs with a safe back navigation.

Passed onBackClick callback to allow return from detail to catalog screen.

Testing
Manually tested valid and invalid navigation flows.

Confirmed that invalid company IDs don’t crash the app.

Known Limitations
No dedicated error screen yet for missing companies.

Automated UI tests for navigation are pending.