### PR TITLE
Add posttitleinput composable with validation and character count

### DIFF
--- a/app/src/main/java/com/android/tripbook/posts/ui/components/PostTitleInput.kt
+++ b/app/src/main/java/com/android/tripbook/posts/ui/components/PostTitleInput.kt
@@ -57,7 +57,7 @@ fun PostTitleInput(
             text = "${title.length}/100",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(start = 17.dp, top = 4.dp)
+            modifier = Modifier.padding(start = 16.dp, top = 4.dp)
         )
     }
 }


### PR DESCRIPTION
A central part of the post creation flow is the PostTitleInput composable — a reusable, well-designed input field tailored for writing compelling post titles.

🧩 Component Features:
	•	Material 3 UI with OutlinedTextField
	•	Real-time error validation (e.g., empty or invalid input)
	•	Character count indicator to guide user input (e.g., 0/100)
	•	Word capitalization for better readability
	•	“Next” IME action with smart focus handling
	•	Fully customizable via Modifier

This component encapsulates best practices in Compose UI and promotes accessibility, responsiveness, and UX clarity.
📈 Goals of the Project
	•	Build a modern Compose-based post creation system
	•	Ensure modular and testable UI components
	•	Focus on UX by guiding user input with dynamic UI feedback
	•	Lay the foundation for a full-featured travel post platform (with images, location tagging, and sharing)

📐 Technical Stack
Layer Technology
Language = Kotlin
UI Framework = Jetpack Compose
Design System = Material 3 (M3)
Architecture =  Modular MVVM (planned)
Version Control = Git + GitHub
Build System = Gradle

Preview

![2](https://github.com/user-attachments/assets/63c87b3f-85dc-4f16-8de6-947c4ebbccf1)
