### PR TITLE
Add ViewModeToggleButtons composable to enable toggling between list …

### DIFF
--- a/app/src/main/java/com/android/tripbook/companycatalog/ui/components/ViewModeToggleButtons.kt
+++ b/app/src/main/java/com/android/tripbook/companycatalog/ui/components/ViewModeToggleButtons.kt
@@ -3,3 +3,69 @@ This composable streamlines view mode selection,
 either list or gird form
  */
 package com.android.tripbook.companycatalog.ui.components
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.List // Import for List icon
+import androidx.compose.material.icons.filled.Menu // Import for Menu icon
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon // Import for Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.android.tripbook.ui.theme.Purple700 // Assuming this is your primary app bar color
+import com.android.tripbook.ui.theme.Purple40 // Assuming this is another color in your theme (not directly used here but good to keep if in theme)
+@Composable
+fun ViewModeToggleButtons(
+    isListView: Boolean, // true if list view is active, false if card view is active
+    onToggleView: (Boolean) -> Unit // Lambda to update the view mode
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth() // Occupy entire space width
+            .padding(horizontal = 16.dp, vertical = 4.dp), // Reduced vertical padding from 8.dp to 4.dp
+                horizontalArrangement = Arrangement.spacedBy(8.dp) // Add space between buttons
+    ) {
+        // List View Button
+        Button(
+            onClick = { onToggleView(true) }, // Set isListView to true for list view
+                    modifier = Modifier.weight(1f), // Make this button take equal width
+                    shape = RoundedCornerShape(12.dp), // Rounded corners for the button
+                    colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isListView) Purple700 else
+                        Color.LightGray, // Purple700 for active, Light Gray for inactive
+            contentColor = if (isListView) Color.White else Color.Black
+// Text/Icon color based on background
+                    )
+        ) {
+            Icon( // Replaced Text with Icon
+                imageVector = Icons.AutoMirrored.Filled.List,
+                contentDescription = "List View"
+            )
+        }
+        // Menu/Card View Button
+        Button(
+            onClick = { onToggleView(false) }, // Set isListView to false for card view
+                    modifier = Modifier.weight(1f), // Make this button take equal width
+                    shape = RoundedCornerShape(12.dp), // Rounded corners for the button
+                    colors = ButtonDefaults.buttonColors(
+                    containerColor = if (!isListView) Purple700 else
+                        Color.LightGray, // Purple700 for active, Light Gray for inactive
+            contentColor = if (!isListView) Color.White else Color.Black
+// Text/Icon color based on background
+        )
+        ) {
+        Icon( // Replaced Text with Icon
+            imageVector = Icons.Filled.Menu,
+            contentDescription = "Card View"
+        )
+    }
+    }
+}


### PR DESCRIPTION
Summary
This PR adds a reusable ViewModeToggleButtons composable to the Company Catalog module of the TripBook app. It improves user experience by providing an intuitive interface to switch between list and card (grid) view layouts, promoting flexible data presentation and enhancing visual control.

 Key Features Implemented
 View Mode Toggle UI
Two equally sized toggle buttons for list and card view modes

Uses intuitive icons: List and Menu

Dynamically highlights the active view mode using the app's theme colors (Purple700, LightGray)

 State-Driven Design
Accepts:

isListView: Boolean — determines the current view state

onToggleView: (Boolean) -> Unit — lambda to handle state updates externally

Supports MVVM-friendly state lifting for flexible reuse in screens

 Visual Feedback and Theming
Clear visual cues through color changes for active/inactive buttons

Maintains color consistency using the app’s theme (Purple700, Color.White, Color.Black)

Icons provide accessible descriptions for screen readers

Responsive Layout
Uses Modifier.fillMaxWidth() for full-width layout

Equal space distribution using Modifier.weight(1f) for both buttons

Horizontal spacing via Arrangement.spacedBy(8.dp)

Rounded corners with RoundedCornerShape(12.dp) to match modern UI trends

Architecture Alignment
Located in com.android.tripbook.companycatalog.ui.components

Lightweight, modular, and reusable

Aligned with Jetpack Compose best practices and Material 3 guidelines

 Testing
Manual UI verification in emulator

Verified:

Toggle behavior and state switching

Active/inactive visual feedback

Layout adaptability on various screen sizes

Planned: Integrate into Company List UI to allow view switching at runtime

 Screenshots 
![2d2494ca-b0aa-4459-afdd-3a7ee2da50bc](https://github.com/user-attachments/assets/b6ccc351-82d1-4359-869b-ec0f951fcd3b)
