### PR TITLE
Userprofile module integration Azieh Godwill

### DIFF
--- a/app/src/main/java/com/android/tripbook/AndroidManifest.xml
+++ b/app/src/main/java/com/android/tripbook/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<activity android:name=".profile.ui.ProfileActivity" />
+<activity android:name=".home.HomeActivity" />

--- a/app/src/main/java/com/android/tripbook/Profile/ProfileIntegrationAdapter.kt
+++ b/app/src/main/java/com/android/tripbook/Profile/ProfileIntegrationAdapter.kt
@@ -1,0 +1,20 @@
+package com.yourpackage.profile
+
+import android.content.Context
+import android.content.Intent
+import com.yourpackage.profile.ui.ProfileActivity
+import com.yourpackage.profile.ui.EditProfileActivity
+
+class ProfileIntegrationAdapter(private val context: Context) : ProfileModuleInterface {
+    override fun openUserProfile(userId: String) {
+        val intent = Intent(context, ProfileActivity::class.java)
+        intent.putExtra("USER_ID", userId)
+        context.startActivity(intent)
+    }
+
+    override fun editUserProfile(userId: String) {
+        val intent = Intent(context, EditProfileActivity::class.java)
+        intent.putExtra("USER_ID", userId)
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/android/tripbook/Profile/ProfileModuleInterface.kt
+++ b/app/src/main/java/com/android/tripbook/Profile/ProfileModuleInterface.kt
@@ -1,0 +1,6 @@
+package com.yourpackage.profile
+
+interface ProfileModuleInterface {
+    fun openUserProfile(userId: String)
+    fun editUserProfile(userId: String)
+}

--- a/app/src/main/java/com/android/tripbook/Profile/ProfileNavigator.kt
+++ b/app/src/main/java/com/android/tripbook/Profile/ProfileNavigator.kt
@@ -1,0 +1,13 @@
+package com.yourpackage.profile
+
+import android.content.Context
+import android.content.Intent
+import com.yourpackage.profile.ui.ProfileActivity
+
+class ProfileNavigator(private val context: Context) : ProfileModuleInterface {
+    override fun openProfile(userId: String) {
+        val intent = Intent(context, ProfileActivity::class.java)
+        intent.putExtra("USER_ID", userId)
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/java/com/android/tripbook/home/HomeActivity.kt
+++ b/app/src/main/java/com/android/tripbook/home/HomeActivity.kt
@@ -3,12 +3,19 @@ package com.yourpackage.home
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.yourpackage.profile.ProfileIntegrationAdapter
+import com.yourpackage.profile.ProfileNavigator
+import com.yourpackage.R
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_home)
 
-        val profileAdapter = ProfileIntegrationAdapter(this)
-        profileAdapter.openUserProfile("12345") // Example user ID
+        // Register the ProfileNavigator
+        ProfileIntegrationAdapter.registerInterface(ProfileNavigator(this))
+
+        // Example usage (replace with actual user logic)
+        val userId = "user_123"
+        ProfileIntegrationAdapter.navigateToProfile(userId)
     }
 }

--- a/app/src/main/java/com/android/tripbook/home/HomeActivity.kt
+++ b/app/src/main/java/com/android/tripbook/home/HomeActivity.kt
@@ -1,0 +1,14 @@
+package com.yourpackage.home
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.yourpackage.profile.ProfileIntegrationAdapter
+
+class HomeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val profileAdapter = ProfileIntegrationAdapter(this)
+        profileAdapter.openUserProfile("12345") // Example user ID
+    }
+}

--- a/app/src/main/java/com/android/tripbook/home/HomeNavigator.kt
+++ b/app/src/main/java/com/android/tripbook/home/HomeNavigator.kt
@@ -1,0 +1,9 @@
+package com.yourpackage.home
+
+import android.app.Activity
+
+class HomeNavigator(private val activity: Activity) {
+    fun goBackHome() {
+        activity.finish()
+    }
+}

--- a/app/src/main/java/com/android/tripbook/userprofile/data/models/SocialLinks.kt
+++ b/app/src/main/java/com/android/tripbook/userprofile/data/models/SocialLinks.kt
@@ -1,0 +1,8 @@
+package com.yourpackage.userprofile.data.models
+
+data class SocialLinks(
+    val facebook: String? = null,
+    val twitter: String? = null,
+    val instagram: String? = null,
+    val linkedin: String? = null
+)

--- a/app/src/main/java/com/android/tripbook/userprofile/data/models/UserProfile.kt
+++ b/app/src/main/java/com/android/tripbook/userprofile/data/models/UserProfile.kt
@@ -1,0 +1,10 @@
+package com.tripbook.userprofile.data.models
+
+data class UserProfile(
+    val userId: String,
+    val fullName: String,
+    val email: String,
+    val phoneNumber: String?,
+    val profileImageUrl: String?,
+    val dateJoined: Long
+)

--- a/app/src/main/java/com/android/tripbook/userprofile/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/android/tripbook/userprofile/data/repository/UserRepository.kt
@@ -1,0 +1,55 @@
+package com.yourpackage.userprofile.data.repository
+
+import com.yourpackage.userprofile.data.models.*
+
+class UserRepository {
+
+    // Simulated user profile data (in a real app, this comes from a server or database)
+    private val dummyUser = User(
+        id = "U12345",
+        username = "godwillazieh",
+        fullName = "Azieh Godwill",
+        email = "azieh@example.com",
+        address = Address(
+            street = "123 Innovation Blvd",
+            city = "Yaoundé",
+            country = "Cameroon",
+            postalCode = "237"
+        ),
+        contactInfo = ContactInfo(
+            phoneNumber = "+237678000111",
+            email = "azieh@example.com"
+        ),
+        emergencyContact = EmergencyContact(
+            name = "Jane Doe",
+            relationship = "Sister",
+            phone = "+237690123456"
+        ),
+        preferences = UserPreferences(
+            prefersDarkMode = true,
+            language = "en",
+            notificationsEnabled = true
+        ),
+        profilePicture = ProfilePicture(
+            url = "https://example.com/profile.jpg",
+            lastUpdated = "2025-05-26T12:00:00Z"
+        ),
+        documents = listOf(
+            Document(
+                type = "Passport",
+                number = "P123456789",
+                expirationDate = "2030-01-01"
+            )
+        )
+    )
+
+    fun getUserProfile(): User {
+        return dummyUser
+    }
+
+    fun updateUserProfile(updatedUser: User): Boolean {
+        // In a real scenario, you would perform an API call or DB update
+        println("User profile updated: $updatedUser")
+        return true
+    }
+}

--- a/app/src/main/java/com/android/tripbook/userprofile/data/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/android/tripbook/userprofile/data/viewmodel/UserViewModel.kt
@@ -1,0 +1,30 @@
+package com.yourpackage.userprofile.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.yourpackage.userprofile.data.models.User
+import com.yourpackage.userprofile.data.repository.UserRepository
+
+class UserViewModel : ViewModel() {
+
+    private val repository = UserRepository()
+
+    private val _userProfile = MutableLiveData<User>()
+    val userProfile: LiveData<User> get() = _userProfile
+
+    init {
+        loadUserProfile()
+    }
+
+    private fun loadUserProfile() {
+        val user = repository.getUserProfile()
+        _userProfile.value = user
+    }
+
+    fun updateUser(updatedUser: User) {
+        if (repository.updateUserProfile(updatedUser)) {
+            _userProfile.value = updatedUser
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements Task T4: **Module Integration** for the User Profile Management module in the TripBook Android application. The changes facilitate interaction between the **Profile** and **Home** modules using clean architectural practices.

**What’s Included:**

✅ `ProfileModuleInterface.kt`: Defines a standard interface for profile module access.
✅ `ProfileNavigator.kt`: Implements the navigation logic to launch the ProfileActivity with the provided user ID.
✅ `ProfileIntegrationAdapter.kt`: Acts as a central adapter to allow the Home module (or others) to call profile-related functions.
✅ Updates in `HomeActivity.kt`:

Registers the `ProfileNavigator` to `ProfileIntegrationAdapter`.
Demonstrates example navigation from Home to Profile.
Optional: `HomeNavigator.kt` for future backward navigation from Profile to Home.

**Purpose:**

To enable cross-module navigation while maintaining loose coupling.
To provide a centralized, scalable interface for launching profile-related activities from other parts of the app.
---
✅ How to Test:

1. Run the app.
2. Open `HomeActivity`.
3. The activity should launch `ProfileActivity` with the user ID passed via intent.

---
Additional Notes:

Make sure `ProfileActivity.kt` is created under `profile.ui`.
Register both activities in `AndroidManifest.xml`.
No breaking changes introduced.
![gg](https://github.com/user-attachments/assets/8bc9ce78-da00-41e4-a8cd-ff41da4483d0)
